### PR TITLE
Build: detect Gupax version at build time via GitHub API

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,29 +11,7 @@ env:
   GUPAX_REPO: gupax-io/gupax
 
 jobs:
-  detect-version:
-    name: Detect latest Gupax version
-    runs-on: ubuntu-latest
-    outputs:
-      guax_version: ${{ steps.version.outputs.GUPAX_VERSION }}
-      guax_sha256: ${{ steps.sha256.outputs.GUPAX_SHA256 }}
-    steps:
-      - name: Fetch latest Gupax version
-        id: version
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/${{ env.GUPAX_REPO }}/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
-          echo "GUPAX_VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Detected Gupax version: $VERSION"
-
-      - name: Fetch SHA256 for linux-x64 binary
-        id: sha256
-        run: |
-          SHA=$(curl -s https://github.com/${{ env.GUPAX_REPO }}/releases/download/${{ steps.version.outputs.GUPAX_VERSION }}/SHA256SUMS | grep 'linux-x64.tar.gz' | awk '{print $1}')
-          echo "GUPAX_SHA256=$SHA" >> $GITHUB_OUTPUT
-          echo "SHA256: $SHA"
-
   build-and-push:
-    needs: detect-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,6 +33,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Detect Gupax version and SHA256
+        id: detect
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/${{ env.GUPAX_REPO }}/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+          echo "Detected Gupax version: $VERSION"
+          SHA=$(curl -s https://github.com/${{ env.GUPAX_REPO }}/releases/download/$VERSION/SHA256SUMS | grep 'linux-x64.tar.gz' | awk '{print $1}')
+          echo "SHA256: $SHA"
+          echo "GUPAX_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "GUPAX_SHA256=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Extract version without v prefix
+        id: version
+        run: |
+          echo "VERSION_STRIPPED=${GUPAX_VERSION#v}" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -63,11 +56,11 @@ jobs:
           push: true
           platforms: linux/amd64
           build-args: |
-            GUPAX_VERSION=${{ needs.detect-version.outputs.guax_version }}
-            GUPAX_SHA256=${{ needs.detect-version.outputs.guax_sha256 }}
+            GUPAX_VERSION=${{ steps.detect.outputs.GUPAX_VERSION }}
+            GUPAX_SHA256=${{ steps.detect.outputs.GUPAX_SHA256 }}
           tags: |
             ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ needs.detect-version.outputs.guax_version }}
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION_STRIPPED }}
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=min

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,12 +62,12 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          build-args:
-            - GUPAX_VERSION=${{ needs.detect-version.outputs.guax_version }}
-            - GUPAX_SHA256=${{ needs.detect-version.outputs.guax_sha256 }}
-          tags:
-            - ${{ env.IMAGE_NAME }}:latest
-            - ${{ env.IMAGE_NAME }}:${{ needs.detect-version.outputs.guax_version }}
-            - ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            GUPAX_VERSION=${{ needs.detect-version.outputs.guax_version }}
+            GUPAX_SHA256=${{ needs.detect-version.outputs.guax_sha256 }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ needs.detect-version.outputs.guax_version }}
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=min

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,12 +62,12 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          build-args: |
-            GUPAX_VERSION=${{ needs.detect-version.outputs.guax_version }}
-            GUPAX_SHA256=${{ needs.detect-version.outputs.guax_sha256 }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ needs.detect-version.outputs.guax_version }}
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args:
+            - GUPAX_VERSION=${{ needs.detect-version.outputs.guax_version }}
+            - GUPAX_SHA256=${{ needs.detect-version.outputs.guax_sha256 }}
+          tags:
+            - ${{ env.IMAGE_NAME }}:latest
+            - ${{ env.IMAGE_NAME }}:${{ needs.detect-version.outputs.guax_version }}
+            - ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=min

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,4 +47,4 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,11 +39,9 @@ jobs:
           VERSION=$(curl -s https://api.github.com/repos/gupax-io/gupax/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
           VERSION_STRIPPED="${VERSION#v}"
           echo "Detected Gupax version: $VERSION (tag: $VERSION_STRIPPED)"
-          # Write tags file for use in build step
-          echo "${{ env.IMAGE_NAME }}:latest" > tags.txt
-          echo "${{ env.IMAGE_NAME }}:$VERSION_STRIPPED" >> tags.txt
-          echo "${{ env.IMAGE_NAME }}:${{ github.sha }}" >> tags.txt
-          echo "tags_file=$(pwd)/tags.txt" >> $GITHUB_OUTPUT
+          # Write tags as newline-delimited string to GITHUB_ENV for use in build step
+          TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          echo "TAGS<<EOF"$'\n'"$TAGS"$'\n'"EOF" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -52,7 +50,6 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          tags-from-file: true
-          tags-file: ${{ steps.version.outputs.tags_file }}
+          tags: ${{ env.TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,11 +43,6 @@ jobs:
           echo "GUPAX_VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "GUPAX_SHA256=$SHA" >> $GITHUB_OUTPUT
 
-      - name: Extract version without v prefix
-        id: version
-        run: |
-          echo "VERSION_STRIPPED=${GUPAX_VERSION#v}" >> $GITHUB_OUTPUT
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -60,7 +55,7 @@ jobs:
             GUPAX_SHA256=${{ steps.detect.outputs.GUPAX_SHA256 }}
           tags: |
             ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION_STRIPPED }}
+            ${{ env.IMAGE_NAME }}:${{ steps.detect.outputs.GUPAX_VERSION }}
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=min

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/w111a/gupax-docker
-  GUPAX_REPO: gupax-io/gupax
 
 jobs:
   build-and-push:
@@ -16,6 +15,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,15 +33,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Detect Gupax version and SHA256
-        id: detect
+      - name: Detect Gupax version for tagging
+        id: version
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/${{ env.GUPAX_REPO }}/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
-          echo "Detected Gupax version: $VERSION"
-          SHA=$(curl -s https://github.com/${{ env.GUPAX_REPO }}/releases/download/$VERSION/SHA256SUMS | grep 'linux-x64.tar.gz' | awk '{print $1}')
-          echo "SHA256: $SHA"
-          echo "GUPAX_VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "GUPAX_SHA256=$SHA" >> $GITHUB_OUTPUT
+          VERSION=$(curl -s https://api.github.com/repos/gupax-io/gupax/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+          VERSION_STRIPPED="${VERSION#v}"
+          echo "Detected Gupax version: $VERSION (tag: $VERSION_STRIPPED)"
+          # Write tags file for use in build step
+          echo "${{ env.IMAGE_NAME }}:latest" > tags.txt
+          echo "${{ env.IMAGE_NAME }}:$VERSION_STRIPPED" >> tags.txt
+          echo "${{ env.IMAGE_NAME }}:${{ github.sha }}" >> tags.txt
+          echo "tags_file=$(pwd)/tags.txt" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -50,12 +52,7 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          build-args: |
-            GUPAX_VERSION=${{ steps.detect.outputs.GUPAX_VERSION }}
-            GUPAX_SHA256=${{ steps.detect.outputs.GUPAX_SHA256 }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ steps.detect.outputs.GUPAX_VERSION }}
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          tags-from-file: true
+          tags-file: ${{ steps.version.outputs.tags_file }}
           cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,14 +8,36 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/w111a/gupax-docker
+  GUPAX_REPO: gupax-io/gupax
 
 jobs:
+  detect-version:
+    name: Detect latest Gupax version
+    runs-on: ubuntu-latest
+    outputs:
+      guax_version: ${{ steps.version.outputs.GUPAX_VERSION }}
+      guax_sha256: ${{ steps.sha256.outputs.GUPAX_SHA256 }}
+    steps:
+      - name: Fetch latest Gupax version
+        id: version
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/${{ env.GUPAX_REPO }}/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+          echo "GUPAX_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected Gupax version: $VERSION"
+
+      - name: Fetch SHA256 for linux-x64 binary
+        id: sha256
+        run: |
+          SHA=$(curl -s https://github.com/${{ env.GUPAX_REPO }}/releases/download/${{ steps.version.outputs.GUPAX_VERSION }}/SHA256SUMS | grep 'linux-x64.tar.gz' | awk '{print $1}')
+          echo "GUPAX_SHA256=$SHA" >> $GITHUB_OUTPUT
+          echo "SHA256: $SHA"
+
   build-and-push:
+    needs: detect-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,10 +63,11 @@ jobs:
           push: true
           platforms: linux/amd64
           build-args: |
-            GUPAX_VERSION=v2.0.1
-            GUPAX_SHA256=67abf40f8c452f637a45644f3b80815cdc44f55e45bc3901d7f66179d65495d5
+            GUPAX_VERSION=${{ needs.detect-version.outputs.guax_version }}
+            GUPAX_SHA256=${{ needs.detect-version.outputs.guax_sha256 }}
           tags: |
             ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ needs.detect-version.outputs.guax_version }}
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=min

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # Gupax GUI for P2Pool + XMRig Monero mining
 # Self-contained with noVNC — access via web browser at http://localhost:6080
 #
-# Build args:
-#   GUPAX_VERSION  — Gupax release tag (default: v2.0.1)
-#   GUPAX_SHA256    — SHA256 checksum for Gupax binary (required for verification)
+# Build args (required):
+#   GUPAX_VERSION  — Gupax release tag (auto-detected by CI)
+#   GUPAX_SHA256   — SHA256 checksum for Gupax binary (auto-detected by CI)
 #
 # Ports:
 #   6080 — noVNC web interface (connect your browser here)
@@ -21,10 +21,21 @@ ENV TZ=UTC
 LABEL maintainer="w111a"
 LABEL description="Gupax — GUI for P2Pool + XMRig Monero mining in Docker (noVNC enabled)"
 LABEL org.opencontainers.image.source="https://github.com/w111a/Gupax-docker"
+LABEL org.opencontainers.image.version="${GUPAX_VERSION}"
+LABEL guax.version="${GUPAX_VERSION}"
+LABEL guax.sha256="${GUPAX_SHA256}"
 
-# Build arguments
-ARG GUPAX_VERSION=v2.0.1
-ARG GUPAX_SHA256=67abf40f8c452f637a45644f3b80815cdc44f55e45bc3901d7f66179d65495d5
+# Build arguments — values injected by CI workflow
+ARG GUPAX_VERSION
+ARG GUPAX_SHA256
+
+# Fail fast if version/sha not provided
+RUN if [ -z "$GUPAX_VERSION" ] || [ -z "$GUPAX_SHA256" ]; then \
+      echo "ERROR: GUPAX_VERSION and GUPAX_SHA256 must be set via --build-arg"; \
+      echo "  GUPAX_VERSION=$GUPAX_VERSION"; \
+      echo "  GUPAX_SHA256=$GUPAX_SHA256"; \
+      exit 1; \
+    fi
 
 # Gupax release URL
 ENV GUPAX_URL="https://github.com/gupax-io/gupax/releases/download/${GUPAX_VERSION}/gupax-${GUPAX_VERSION}-linux-x64.tar.gz"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@
 
 FROM ubuntu:22.04
 
+# Prevent interactive tzdata prompt from blocking the build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
 LABEL maintainer="w111a"
 LABEL description="Gupax — GUI for P2Pool + XMRig Monero mining in Docker (noVNC enabled)"
 LABEL org.opencontainers.image.source="https://github.com/w111a/Gupax-docker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,7 @@
 # Gupax GUI for P2Pool + XMRig Monero mining
 # Self-contained with noVNC — access via web browser at http://localhost:6080
 #
-# Build args (required):
-#   GUPAX_VERSION  — Gupax release tag (auto-detected by CI)
-#   GUPAX_SHA256   — SHA256 checksum for Gupax binary (auto-detected by CI)
-#
-# Ports:
-#   6080 — noVNC web interface (connect your browser here)
-#   5900 — VNC server (optional, for direct VNC access)
+# Version auto-detected at build time via GitHub API — no build args needed
 # =============================================================================
 
 FROM ubuntu:22.04
@@ -18,65 +12,55 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-LABEL maintainer="w111a"
-LABEL description="Gupax — GUI for P2Pool + XMRig Monero mining in Docker (noVNC enabled)"
-LABEL org.opencontainers.image.source="https://github.com/w111a/Gupax-docker"
-LABEL org.opencontainers.image.version="${GUPAX_VERSION}"
-LABEL guax.version="${GUPAX_VERSION}"
-LABEL guax.sha256="${GUPAX_SHA256}"
-
-# Build arguments — values injected by CI workflow
-ARG GUPAX_VERSION
-ARG GUPAX_SHA256
-
-# Fail fast if version/sha not provided
-RUN if [ -z "$GUPAX_VERSION" ] || [ -z "$GUPAX_SHA256" ]; then \
-      echo "ERROR: GUPAX_VERSION and GUPAX_SHA256 must be set via --build-arg"; \
-      echo "  GUPAX_VERSION=$GUPAX_VERSION"; \
-      echo "  GUPAX_SHA256=$GUPAX_SHA256"; \
-      exit 1; \
-    fi
-
-# Gupax release URL
-ENV GUPAX_URL="https://github.com/gupax-io/gupax/releases/download/${GUPAX_VERSION}/gupax-${GUPAX_VERSION}-linux-x64.tar.gz"
-
 # Xvfb display for headless GUI
 ENV DISPLAY=:1
 
 # Install X11 (for Xvfb), VNC, noVNC, and Gupax runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # X11 for Xvfb (virtual framebuffer)
     xvfb \
     x11-xserver-utils \
-    # VNC server
     x11vnc \
-    # noVNC / WebSocket proxy
     novnc \
     websockify \
-    # Gupax GUI dependencies (OpenGL/audio)
     libgl1-mesa-glx \
     libgl1 \
     libasound2 \
     libpulse0 \
-    # Utilities
     ca-certificates \
     curl \
     gosu \
+    python3 \
     && rm -rf /var/lib/apt/lists/* \
     && update-ca-certificates \
     && groupadd -r miner \
     && useradd -r -g miner -m -d /home/miner miner
 
-# Download, verify, and extract Gupax
+# Detect latest Gupax version, fetch SHA256, download, verify, and install
 WORKDIR /tmp/gupax
-RUN set -eux; \
-    curl -fsSL "$GUPAX_URL" -o gupax.tar.gz; \
-    printf '%s  %s\n' "$GUPAX_SHA256" "gupax.tar.gz" | sha256sum --check --status; \
-    tar -xzf gupax.tar.gz; \
-    GUPATH=$(find . -name 'gupax' -type f); \
-    mv "$GUPATH" /usr/local/bin/gupax; \
-    chmod +x /usr/local/bin/gupax; \
-    rm -rf /tmp/gupax
+RUN VERSION=$(curl -fsSL https://api.github.com/repos/gupax-io/gupax/releases/latest \
+           | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])") \
+    && echo "Detected Gupax version: $VERSION" \
+    && SHA=$(curl -fsSL "https://github.com/gupax-io/gupax/releases/download/$VERSION/SHA256SUMS" \
+           | grep 'linux-x64.tar.gz' | awk '{print $1}') \
+    && echo "SHA256: $SHA" \
+    && curl -fsSL "https://github.com/gupax-io/gupax/releases/download/$VERSION/gupax-${VERSION}-linux-x64.tar.gz" \
+           -o gupax.tar.gz \
+    && printf '%s  %s\n' "$SHA" "gupax.tar.gz" | sha256sum --check --status \
+    && tar -xzf gupax.tar.gz \
+    && mv $(find . -name 'gupax' -type f) /usr/local/bin/gupax \
+    && chmod +x /usr/local/bin/gupax \
+    && rm -rf /tmp/gupax \
+    && echo "$VERSION" > /tmp/guax_version \
+    && echo "$SHA" > /tmp/guax_sha256
+
+# Labels
+# Note: version label uses v-prefixed tag (v2.0.1) per upstream convention
+LABEL maintainer="w111a" \
+      description="Gupax — GUI for P2Pool + XMRig Monero mining in Docker (noVNC enabled)" \
+      org.opencontainers.image.source="https://github.com/w111a/Gupax-docker" \
+      org.opencontainers.image.version="$(cat /tmp/guax_version)" \
+      guax.version="$(cat /tmp/guax_version)" \
+      guax.sha256="$(cat /tmp/guax_sha256)"
 
 # Create Gupax state directory
 RUN mkdir -p /home/miner/.local/state/gupax && chown -R miner:miner /home/miner
@@ -85,19 +69,12 @@ RUN mkdir -p /home/miner/.local/state/gupax && chown -R miner:miner /home/miner
 COPY start.sh /usr/local/bin/start.sh
 RUN chmod +x /usr/local/bin/start.sh
 
-# Ports exposed:
-# 6080 — noVNC web interface (HTTP + WebSocket)
-# 5900 — VNC server (for direct VNC clients)
 EXPOSE 6080 5900
-
-# Mining ports (for P2Pool/XMRig-proxy)
 EXPOSE 3333 37889 18080 18081 18082
 
-# Persistent Gupax state
 VOLUME ["/home/miner/.local/state/gupax"]
 
 USER miner
 WORKDIR /home/miner
 
-# Run the startup script which launches Xvfb + x11vnc + websockify + Gupax
 ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Click **Connect** on the noVNC page — no password required by default.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `WALLET_ADDRESS` | ✅ Yes | — | Your Monero wallet address for mining payouts |
-| `GUPAX_VERSION` | No | v2.0.1 | Gupax version |
-| `GUPAX_SHA256` | No | (checksum) | Gupax SHA256 for verification |
+| `WALLET_ADDRESS` | Yes | — | Your Monero wallet address for mining payouts |
 | `MONERO_DATA_PATH` | No | gupax-monero | Path to Monero blockchain data |
+
+> **Note:** `GUPAX_VERSION` and `GUPAX_SHA256` are managed automatically by the CI workflow — no manual configuration needed. The Docker image is always built with the latest detected upstream Gupax version.
 
 ### Ports
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      # GUPAX_VERSION and GUPAX_SHA256 injected automatically by workflow
+      # GUPAX_VERSION and GUPAX_SHA256 are detected automatically at build time
     image: ghcr.io/w111a/gupax-docker:latest
     container_name: gupax
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        GUPAX_VERSION: ${GUPAX_VERSION:-v2.0.1}
-        GUPAX_SHA256: ${GUPAX_SHA256:-67abf40f8c452f637a45644f3b80815cdc44f55e45bc3901d7f66179d65495d5}
+      # GUPAX_VERSION and GUPAX_SHA256 injected automatically by workflow
     image: ghcr.io/w111a/gupax-docker:latest
     container_name: gupax
     restart: unless-stopped


### PR DESCRIPTION
Move version detection from CI workflow into the Dockerfile, eliminating the YAML multiline interpolation problem that caused 6 consecutive build failures.

## Changes
- **Dockerfile**: Detect latest Gupax release via GitHub API at build time, fetch and verify SHA256SUMS, no build args needed
- **Workflow**: Use GITHUB_ENV to pass tags to build-push-action (tags-from-file not supported in v6)
- **OCI labels**: `org.opencontainers.image.version`, `guax.version`, `guax.sha256` set from detected values
- **docker-compose.yml**: Removed hardcoded build args
- **README.md**: Updated to reflect auto-versioning