### PR TITLE
Dockerfile: strip v prefix for OCI label (2.0.1 not v2.0.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN VERSION=$(curl -fsSL https://api.github.com/repos/gupax-io/gupax/releases/la
     && mv $(find . -name 'gupax' -type f) /usr/local/bin/gupax \
     && chmod +x /usr/local/bin/gupax \
     && rm -rf /tmp/gupax \
-    && echo "$VERSION" > /tmp/guax_version \
+    && echo "${VERSION#v}" > /tmp/guax_version \
     && echo "$SHA" > /tmp/guax_sha256
 
 # Labels


### PR DESCRIPTION
Strip the `v` prefix from the version stored in `/tmp/guax_version` so the OCI label `org.opencontainers.image.version` reads `2.0.1` instead of `v2.0.1`, matching the human-readable format preference.