### PR TITLE
Merge hardening: 13 security fixes from feat-tor-node-standalone-hard

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feat/tor-node-standalone
+      - feat-tor-node-standalone-hard
   workflow_dispatch:
 
 jobs:
@@ -22,7 +23,7 @@ jobs:
           additional_files: 'start.sh'
 
       - name: Hadolint (Dockerfile)
-        uses: hadolint/hadolint-action@v3
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile
           failure-threshold: warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # and persisted in /home/miner/.local/share/gupax via the gupax-share volume.
 # =============================================================================
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4fff072216d2d3d6accc8bc09b57c33e474edd726f3f65fbadbb05647ab15fa5
 
 # Prevent interactive tzdata prompt from blocking the build
 ENV DEBIAN_FRONTEND=noninteractive
@@ -54,9 +54,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Allow passwordless sudo for XMRig — Gupax on Linux spawns XMRig via pkexec
 # which is unavailable in Docker; we provide a pkexec→sudo wrapper instead.
-# Use ALL (not a specific username) because the effective user is the
-# gosu-dropped PUID (e.g., 99 on Unraid), not the image-layer 'miner' user.
-RUN echo "ALL ALL=(ALL) NOPASSWD: /home/miner/.local/share/gupax/xmrig/xmrig" > /etc/sudoers.d/gupax-xmrig \
+# Restrict to %gupax group (created by start.sh's useradd for the gosu-dropped
+# UID) rather than ALL, to limit the writable-volume sudo escalation surface.
+RUN echo "%gupax ALL=(ALL) NOPASSWD: /home/miner/.local/share/gupax/xmrig/xmrig" > /etc/sudoers.d/gupax-xmrig \
     && chmod 0440 /etc/sudoers.d/gupax-xmrig
 
 # Provide a pkexec wrapper that delegates to sudo (no PolicyKit agent in container)

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,8 @@ RUN chmod +x /usr/local/bin/start.sh
 
 EXPOSE 6080 5900
 EXPOSE 3333 37889 18080 18081 18082
+# Tor hidden service ports (internal only — documented for debugging)
+EXPOSE 18084 18086
 
 # Pre-create .bitmonero directory with miner ownership.
 # No .bitmonero symlink needed — monerod resolves its data directory via $HOME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       # - VNC_PASSWORD=change-me  # Uncomment to require VNC password
     volumes:
       - gupax-data:/home/miner/.local/share/gupax       # Config + runtime data
+      - gupax-state:/home/miner/.local/state/gupax      # Gupax XDG state (session cache)
       - ${MONERO_DATA_PATH:-gupax-monero}:/home/miner/.bitmonero  # Blockchain
       - gupax-tor:/home/miner/.tor                       # Persistent .onion address
     ports:
@@ -26,13 +27,23 @@ services:
       - "18080:18080" # Monero P2P
       - "18081:18081" # Monero RPC
       - "18082:18082" # Monero RPC ZMQ
+    # Anonymous inbound hidden service: Tor virtual 18084 → 127.0.0.1:18086
     logging:
       driver: json-file
       options:
         max-size: "10m"
         max-file: "3"
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+        reservations:
+          cpus: '1.0'
+          memory: 1G
 
 volumes:
   gupax-data:
+  gupax-state:
   gupax-monero:
   gupax-tor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@ services:
       - gupax-tor:/home/miner/.tor                       # Persistent .onion address
     ports:
       - "6080:6080"   # noVNC web interface
-      - "5900:5900"   # VNC server (optional)
+      # VNC server — only uncomment if you've set VNC_PASSWORD above.
+      # Exposing raw VNC without a password gives anyone on your network
+      # full GUI control (change wallets, start/stop mining, etc.).
+      # - "5900:5900"
       - "3333:3333"   # P2Pool stratum server
       - "37889:37889" # P2Pool Monero node ZMQ
       - "18080:18080" # Monero P2P

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     # Drop all Linux capabilities, then add back only the minimum needed:
     # - SETUID/SETGID: gosu drops privileges from root to the mining user
     # - DAC_OVERRIDE: root must create/write files in /home/miner volume
+    # - FOWNER: required for file operations when ownership changes at runtime
     # - CHOWN: start.sh fixes volume ownership at container startup
     cap_drop:
       - ALL
@@ -58,6 +59,7 @@ services:
       - SETUID
       - SETGID
       - DAC_OVERRIDE
+      - FOWNER
       - CHOWN
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,17 @@ services:
         reservations:
           cpus: '1.0'
           memory: 1G
-    # Drop all Linux capabilities — none of the services in this container
-    # (Tor, noVNC, Gupax, monerod, P2Pool, XMRig) use privileged ports
-    # (>1024) or require special kernel capabilities at default config.
+    # Drop all Linux capabilities, then add back only the minimum needed:
+    # - SETUID/SETGID: gosu drops privileges from root to the mining user
+    # - DAC_OVERRIDE: root must create/write files in /home/miner volume
+    # - CHOWN: start.sh fixes volume ownership at container startup
     cap_drop:
       - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+      - CHOWN
 
 volumes:
   gupax-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       - "18081:18081" # Monero RPC
       - "18082:18082" # Monero RPC ZMQ
     # Anonymous inbound hidden service: Tor virtual 18084 → 127.0.0.1:18086
+    # These are internal-only — not exposed to the host (doing so would
+    # bypass Tor and defeat the purpose of anonymous-inbound).
+    # - "18084:18084"  # Tor hidden service virtual port (do NOT expose)
+    # - "18086:18086"  # monerod anonymous-inbound internal bind (do NOT expose)
     logging:
       driver: json-file
       options:
@@ -41,6 +45,11 @@ services:
         reservations:
           cpus: '1.0'
           memory: 1G
+    # Drop all Linux capabilities — none of the services in this container
+    # (Tor, noVNC, Gupax, monerod, P2Pool, XMRig) use privileged ports
+    # (>1024) or require special kernel capabilities at default config.
+    cap_drop:
+      - ALL
 
 volumes:
   gupax-data:

--- a/start.sh
+++ b/start.sh
@@ -62,7 +62,11 @@ echo "============================================="
 
 # Fix volume permissions — container starts as root, no setpriv needed
 echo "[*] Fixing data directory permissions..."
-chown -R miner:miner /home/miner/.local/share/gupax 2>/dev/null || true
+
+# Detect the user to run Gupax as, matching the data volume owner.
+# Must happen early — chown below needs to target the correct UID/GID.
+PUID=${PUID:-$(stat -c '%u' /home/miner/.local/share/gupax 2>/dev/null || echo "999")}
+PGID=${PGID:-$(stat -c '%g' /home/miner/.local/share/gupax 2>/dev/null || echo "999")}
 
 # Pre-create Gupax binary subdirectories on the persistent volume and symlink
 # them into /usr/local/bin/gupax/ so Gupax downloads binaries to the volume,
@@ -71,17 +75,11 @@ for dir in p2pool node xmrig xmrig-proxy; do
     mkdir -p /home/miner/.local/share/gupax/$dir
     ln -sfn /home/miner/.local/share/gupax/$dir /usr/local/bin/gupax/$dir
 done
-chown -R miner:miner /home/miner/.local/share/gupax 2>/dev/null || true
 
-# Safety net: Unraid FUSE filesystems (fuse.shfs) silently ignore chown,
-# so chown above may have done nothing.  Detect the filesystem type and
-# apply relaxed permissions only when actually needed.
-# On normal filesystems (ext4, xfs, overlay, etc.) chown already worked;
-# we just keep parent directories traversable in case the gosu UID
-# doesn't match the image-layer 'miner' (999) user.
+# Safety net: Unraid FUSE filesystems (fuse.shfs) silently ignore chown.
+# Detect the filesystem type and apply relaxed permissions only when needed.
 FS_TYPE=$(stat -f -c '%T' /home/miner/.local/share/gupax 2>/dev/null || echo "unknown")
-# Make parent directories traversable by everyone regardless of ownership
-# (needed for any Docker volume, especially on first run).
+# Make parent directories traversable (needed for any Docker volume).
 chmod a+rx /home/miner /home/miner/.local /home/miner/.local/share 2>/dev/null || true
 
 if [ "$FS_TYPE" = "fuse.shfs" ] || [ "$FS_TYPE" = "fuseblk" ]; then
@@ -92,13 +90,13 @@ if [ "$FS_TYPE" = "fuse.shfs" ] || [ "$FS_TYPE" = "fuseblk" ]; then
     chmod -R a+rwX /home/miner/.local/share/gupax 2>/dev/null || true
     chmod a+rwX /home/miner/.bitmonero 2>/dev/null || true
 else
-    # Normal filesystem: chown already ran successfully above.
-    # Keep things tight — no need for world-writable volumes.
-    echo "[*] Non-FUSE filesystem ($FS_TYPE) — using standard permissions"
-    # Ensure the miner user (UID matches the gosu-dropped user) can access
-    # everything, but don't open it up to the world.
-    chown -R miner:miner /home/miner/.local/share/gupax 2>/dev/null || true
+    # Normal filesystem: chown actually works.
+    # Target the gosu-dropped PUID/PGID (detected above), not the image-layer
+    # 'miner' user, so Gupax can write as the correct UID.
+    echo "[*] Non-FUSE filesystem ($FS_TYPE) — applying standard permissions for UID:$PUID GID:$PGID"
+    chown -R "$PUID:$PGID" /home/miner/.local/share/gupax 2>/dev/null || true
     chmod -R u+rwX,go+rX /home/miner/.local/share/gupax 2>/dev/null || true
+    chown "$PUID:$PGID" /home/miner/.bitmonero 2>/dev/null || true
     chmod u+rwX,go+rX /home/miner/.bitmonero 2>/dev/null || true
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -282,8 +282,16 @@ PGID=${PGID:-$(stat -c '%g' /home/miner/.local/share/gupax 2>/dev/null || echo "
 # A raw 'echo' into passwd has no corresponding shadow entry, so sudo fails:
 # "account validation failure, is your account locked?"
 # useradd creates both entries properly and accepts the NOPASSWD sudoers rule.
+#
+# The Dockerfile sudoers rule uses %gupax (group-based).  On many systems
+# (Unraid especially) PUID=99/PGID=100 maps to nobody:users / nobody:nogroup,
+# so group GID 100 already belongs to a system group.  groupadd -f will
+# silently skip the conflicting GID and assign a different numeric ID,
+# meaning the new user is NOT a member of the gupax group and sudoers never
+# matches.  To fix this we unconditionally add the user to gupax as a
+# supplementary group after creation.
 if ! getent passwd "$PUID" >/dev/null 2>&1; then
-    groupadd -f -g "$PGID" gupax
+    groupadd -f gupax
     useradd -o -M -u "$PUID" -g "$PGID" -d /home/miner -s /bin/bash gupax 2>/dev/null || {
         # Fallback: useradd failed (e.g., read-only rootfs, no shadow).  At minimum get the
         # user into passwd so the container doesn't crash; XMRig may still fail but won't
@@ -291,6 +299,7 @@ if ! getent passwd "$PUID" >/dev/null 2>&1; then
         echo "gupax:x:$PUID:$PGID:Docker user:/home/miner:/bin/bash" >> /etc/passwd
         echo "[!] useradd failed — fallback to /etc/passwd only (XMRig may not start)"
     }
+    usermod -a -G gupax gupax 2>/dev/null || true
     echo "[*] Created gupax user (UID $PUID) for pkexec→sudo support"
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -197,15 +197,20 @@ setxkbmap us 2>/dev/null || echo "[!] setxkbmap failed (non-fatal)"
 
 # Start x11vnc (VNC server sharing Xvfb)
 echo "[*] Starting x11vnc on port 5900..."
-# VNC authentication — use VNC_PASSWORD if set, otherwise disable auth
+# VNC authentication — use VNC_PASSWORD if set, otherwise disable auth.
+# Uses -passwdfile instead of -passwd to avoid exposing the password in
+# /proc/PID/cmdline and to handle passwords with spaces or special characters.
 if [ -n "$VNC_PASSWORD" ]; then
-    VNC_FLAGS="-passwd $VNC_PASSWORD"
+    X11VNC_PASSFILE=$(mktemp)
+    printf '%s' "$VNC_PASSWORD" > "$X11VNC_PASSFILE"
     echo "[*] VNC authentication: enabled (VNC_PASSWORD is set)"
+    x11vnc -display $DISPLAY_NUM -forever -shared -rfbport 5900 \
+        -passwdfile "$X11VNC_PASSFILE" -noxfixes -cursor arrow &
 else
-    VNC_FLAGS="-nopw"
     echo "[*] VNC authentication: DISABLED (set VNC_PASSWORD to enable)"
+    x11vnc -display $DISPLAY_NUM -forever -shared -rfbport 5900 \
+        -nopw -noxfixes -cursor arrow &
 fi
-x11vnc -display $DISPLAY_NUM -forever -shared -rfbport 5900 $VNC_FLAGS -noxfixes -cursor arrow &
 X11VNC_PID=$!
 
 # Re-enable X autorepeat that x11vnc disables on client connect (run 3x as x11vnc recommends)

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,34 @@ for dir in p2pool node xmrig xmrig-proxy; do
 done
 chown -R miner:miner /home/miner/.local/share/gupax 2>/dev/null || true
 
-# Safety net: Unraid FUSE filesystems don't support chown to arbitrary UIDs.
-# Make directories traversable by everyone regardless of ownership.
+# Safety net: Unraid FUSE filesystems (fuse.shfs) silently ignore chown,
+# so chown above may have done nothing.  Detect the filesystem type and
+# apply relaxed permissions only when actually needed.
+# On normal filesystems (ext4, xfs, overlay, etc.) chown already worked;
+# we just keep parent directories traversable in case the gosu UID
+# doesn't match the image-layer 'miner' (999) user.
+FS_TYPE=$(stat -f -c '%T' /home/miner/.local/share/gupax 2>/dev/null || echo "unknown")
+# Make parent directories traversable by everyone regardless of ownership
+# (needed for any Docker volume, especially on first run).
 chmod a+rx /home/miner /home/miner/.local /home/miner/.local/share 2>/dev/null || true
-chmod -R a+rwX /home/miner/.local/share/gupax 2>/dev/null || true
-chmod a+rwX /home/miner/.bitmonero 2>/dev/null || true
+
+if [ "$FS_TYPE" = "fuse.shfs" ] || [ "$FS_TYPE" = "fuseblk" ]; then
+    # Unraid FUSE: chown is silently ignored, so we resort to world-writable
+    # permissions.  This is the only way to make the volume usable when the
+    # gosu-dropped UID (e.g. 99) doesn't own the backing files.
+    echo "[*] Detected FUSE filesystem ($FS_TYPE) — applying relaxed permissions"
+    chmod -R a+rwX /home/miner/.local/share/gupax 2>/dev/null || true
+    chmod a+rwX /home/miner/.bitmonero 2>/dev/null || true
+else
+    # Normal filesystem: chown already ran successfully above.
+    # Keep things tight — no need for world-writable volumes.
+    echo "[*] Non-FUSE filesystem ($FS_TYPE) — using standard permissions"
+    # Ensure the miner user (UID matches the gosu-dropped user) can access
+    # everything, but don't open it up to the world.
+    chown -R miner:miner /home/miner/.local/share/gupax 2>/dev/null || true
+    chmod -R u+rwX,go+rX /home/miner/.local/share/gupax 2>/dev/null || true
+    chmod u+rwX,go+rX /home/miner/.bitmonero 2>/dev/null || true
+fi
 
 # Display number for Xvfb
 DISPLAY_NUM=:1

--- a/start.sh
+++ b/start.sh
@@ -26,6 +26,10 @@ cleanup() {
     echo "[*] Stopping x11vnc..."
     kill $X11VNC_PID 2>/dev/null || true
     wait $X11VNC_PID 2>/dev/null || true
+    # Belt-and-suspenders: remove the password temp file on shutdown
+    # in case it wasn't cleaned up during startup (e.g., container was killed
+    # before the startup-time rm could execute).
+    [ -n "$X11VNC_PASSFILE" ] && rm -f "$X11VNC_PASSFILE"
     echo "[*] Stopping openbox..."
     kill $OPENBOX_PID 2>/dev/null || true
     wait $OPENBOX_PID 2>/dev/null || true
@@ -212,6 +216,11 @@ else
         -nopw -noxfixes -cursor arrow &
 fi
 X11VNC_PID=$!
+# x11vnc runs asynchronously (& above) — give it time to read the
+# passwdfile before we remove it.  x11vnc opens the file once at startup;
+# after that the credential doesn't need to sit in /tmp.
+sleep 1
+[ -n "$X11VNC_PASSFILE" ] && rm -f "$X11VNC_PASSFILE"
 
 # Re-enable X autorepeat that x11vnc disables on client connect (run 3x as x11vnc recommends)
 xset r on 2>/dev/null || true
@@ -275,8 +284,11 @@ echo "[*] Starting Gupax..."
 # Detect the user to run Gupax as, matching the data volume owner.
 # Auto-detected from volume owner; override with PUID/PGID env vars.
 # On Unraid/FUSE shares where chown fails, set PUID=99 PGID=100.
-PUID=${PUID:-$(stat -c '%u' /home/miner/.local/share/gupax 2>/dev/null || echo "0")}
-PGID=${PGID:-$(stat -c '%g' /home/miner/.local/share/gupax 2>/dev/null || echo "0")}
+#
+# On first run the volume directory may not exist yet (stat fails).
+# Fall back to the image-layer 'miner' user instead of root (UID 0).
+PUID=${PUID:-$(stat -c '%u' /home/miner/.local/share/gupax 2>/dev/null || echo "999")}
+PGID=${PGID:-$(stat -c '%g' /home/miner/.local/share/gupax 2>/dev/null || echo "999")}
 
 # sudo requires the current UID to exist in both /etc/passwd and /etc/shadow.
 # A raw 'echo' into passwd has no corresponding shadow entry, so sudo fails:

--- a/start.sh
+++ b/start.sh
@@ -302,15 +302,9 @@ echo "[+] xdg-desktop-portal started (PID $PORTAL_PID)"
 # Start Gupax — runs as child of this script so cleanup() can manage it
 echo "[*] Starting Gupax..."
 
-# Detect the user to run Gupax as, matching the data volume owner.
-# Auto-detected from volume owner; override with PUID/PGID env vars.
-# On Unraid/FUSE shares where chown fails, set PUID=99 PGID=100.
+# PUID/PGID were already detected (or overridden by env vars) during the
+# permission-fix block above — no need to rediscover them.
 #
-# On first run the volume directory may not exist yet (stat fails).
-# Fall back to the image-layer 'miner' user instead of root (UID 0).
-PUID=${PUID:-$(stat -c '%u' /home/miner/.local/share/gupax 2>/dev/null || echo "999")}
-PGID=${PGID:-$(stat -c '%g' /home/miner/.local/share/gupax 2>/dev/null || echo "999")}
-
 # sudo requires the current UID to exist in both /etc/passwd and /etc/shadow.
 # A raw 'echo' into passwd has no corresponding shadow entry, so sudo fails:
 # "account validation failure, is your account locked?"

--- a/templates/gupax-docker.xml
+++ b/templates/gupax-docker.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>gupax</Name>
-  <Repository>libre7/gupax-docker:latest</Repository>
-  <Registry>https://hub.docker.com/r/libre7/gupax-docker</Registry>
+  <Repository>ghcr.io/w111a/gupax-docker:feat-tor-node-standalone-hard</Repository>
+  <Registry>ghcr.io/w111a/gupax-docker</Registry>
   <Network>bridge</Network>
   <Shell>bash</Shell>
   <Privileged>false</Privileged>
@@ -23,6 +23,15 @@ Set your Monero wallet address inside the Gupax GUI itself (Node tab). Mining cr
   <!-- Environment Variables                                        -->
   <!-- ============================================================ -->
   <Environment>
+    <Variable>
+      <Name>TOR_ENABLED</Name>
+      <Value>false</Value>
+      <Mode></Mode>
+      <Description>Enable Tor hidden service for Monero transaction broadcast (tx-only mode, P2P sync stays on clearnet)</Description>
+      <Display>always</Display>
+      <Required>false</Required>
+      <Mask>false</Mask>
+    </Variable>
     <Variable>
       <Name>SCREEN_RESOLUTION</Name>
       <Value>1920x1080x24</Value>

--- a/templates/gupax-docker.xml
+++ b/templates/gupax-docker.xml
@@ -33,6 +33,33 @@ Set your Monero wallet address inside the Gupax GUI itself (Node tab). Mining cr
       <Mask>false</Mask>
     </Variable>
     <Variable>
+      <Name>VNC_PASSWORD</Name>
+      <Value></Value>
+      <Mode></Mode>
+      <Description>Password for VNC web interface access (leave empty for no authentication)</Description>
+      <Display>always</Display>
+      <Required>false</Required>
+      <Mask>true</Mask>
+    </Variable>
+    <Variable>
+      <Name>PUID</Name>
+      <Value>99</Value>
+      <Mode></Mode>
+      <Description>User ID for file permissions (Unraid default: 99)</Description>
+      <Display>advanced</Display>
+      <Required>false</Required>
+      <Mask>false</Mask>
+    </Variable>
+    <Variable>
+      <Name>PGID</Name>
+      <Value>100</Value>
+      <Mode></Mode>
+      <Description>Group ID for file permissions (Unraid default: 100)</Description>
+      <Display>advanced</Display>
+      <Required>false</Required>
+      <Mask>false</Mask>
+    </Variable>
+    <Variable>
       <Name>SCREEN_RESOLUTION</Name>
       <Value>1920x1080x24</Value>
       <Mode></Mode>


### PR DESCRIPTION
## What this merges

13 commits of security hardening from `feat-tor-node-standalone-hard`, all verified on Unraid.

### Summary of changes

**VNC security:**
- Switch from `-passwd` to `-passwdfile` with `mktemp` — password no longer in `/proc/PID/cmdline`
- `printf '%s'` handles passwords with special characters (no word-splitting)
- Password temp file cleaned after x11vnc reads it at startup
- Port 5900 disabled by default in docker-compose.yml

**Sudo hardening:**
- Restricted `NOPASSWD` from bare `ALL` to `%gupax` group
- `usermod -a -G gupax` ensures supplementary group membership on Unraid
- Sudo path scoped only to xmrig binary

**Capability dropping:**
- `cap_drop: ALL` in docker-compose.yml
- Selective `cap_add`: SETUID, SETGID, DAC_OVERRIDE, FOWNER, CHOWN

**Volume permissions:**
- FUSE-aware: `chmod a+rwX` applied only on `fuse.shfs`/`fuseblk` (Unraid)
- Standard filesystems use `u+rwX,go+rX` (755/644)
- `chown` targets the gosu-dropped PUID/PGID instead of static image-layer UID
- PUID/PGID fallback changed from 0 (root) to 999 (miner)

**Build/Compose/XML:**
- Base image pinned to digest `ubuntu:22.04@sha256:4fff...`
- `gupax-state` volume added to docker-compose.yml
- `deploy.resources.limits` (2 CPU, 4G RAM) in compose
- Tor internal ports 18084/18086 in Dockerfile EXPOSE
- Unraid XML: `TOR_ENABLED`, `VNC_PASSWORD` (masked), `PUID`/`PGID` env vars
- Unraid XML: registry switched to GHCR with hardened branch tag

### Issues closed
- #26 — Security Audit: Docker/Container Vulnerability Findings
- #30 — Security Audit and Code Review: feat/tor-node-standalone
- #31 — Hardened Branch Audit (world-writable sudo target, etc.)

### Testing
- VM smoke test: container starts, Tor bootstraps, Gupax runs, sudo works
- Unraid: all verified by user on production Unraid instance