### PR TITLE
fix: CI build-args broken multiline scalar + remove asymmetric paths filter

### DIFF
--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'Dockerfile'
-      - 'docker-compose.yml'
-      - 'start.sh'
-      - '.dockerignore'
-      - '.github/workflows/docker-hub-push.yml'
   workflow_dispatch:
 
 env:
@@ -23,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -54,14 +48,15 @@ jobs:
 
       - name: Build and push to Docker Hub
         uses: docker/build-push-action@v7
+        env:
+          GUPAX_VERSION: ${{ env.VERSION }}
         with:
           context: .
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ env.TAGS }}
-          build-args: |
-            GUPAX_VERSION=${{ env.VERSION }}
+          build-args: GUPAX_VERSION
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -53,14 +53,15 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
+        env:
+          GUPAX_VERSION: ${{ env.VERSION }}
         with:
           context: .
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ env.TAGS }}
-          build-args: |
-            GUPAX_VERSION=${{ env.VERSION }}
+          build-args: GUPAX_VERSION
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max


### PR DESCRIPTION
## Fixes P0 items from #47

### Problem 1: Build-args multiline scalar silently broken

Both workflows used:
```yaml
build-args: |
  GUPAX_VERSION=${{ env.VERSION }}
```

`${{ }}` template expressions **do not interpolate** inside YAML multiline block scalars in `with:` blocks. Docker received the literal string `GUPAX_VERSION=${{ env.VERSION }}` and fell back to the Dockerfile hardcoded default `ARG GUPAX_VERSION=v2.0.1`.

**Result:** The image tag says e.g. `:2.0.3`, but the binary inside is v2.0.1.

### Problem 2: Asymmetric `paths:` filter

The Docker Hub workflow had a `paths:` filter (`Dockerfile`, `start.sh`, etc.) that the GHCR workflow did not. Commits touching only README, LICENSE, templates, or CHANGELOG pushed to GHCR but skipped Docker Hub entirely. Registries have already diverged.

### Changes

- **docker-publish.yml:** Replace `build-args: |` → `env:` + `build-args: GUPAX_VERSION`
- **docker-hub-push.yml:** Same build-args fix + remove `paths:` filter (now matches GHCR trigger)
- **Both:** `actions/checkout@v6` → `@v4` (stable)

### Verification

CI-only diff — no runtime files changed. VM smoke test sufficient per issue lifecycle policy.