### PR TITLE
fix: replace single-shot Gupax pgrep with polling loop in smoke test

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -79,14 +79,21 @@ jobs:
             sleep 4
           done
 
-      - name: Verify Gupax process
+      - name: Wait for Gupax process
+        timeout-minutes: 2
         run: |
-          docker exec gupax-test pgrep -f gupax || {
-            echo "FAIL: Gupax not running"
-            docker logs gupax-test
-            exit 1
-          }
-          echo "Gupax process OK"
+          for i in $(seq 1 15); do
+            if docker exec gupax-test pgrep -f gupax 2>/dev/null; then
+              echo "Gupax ready after ${i} attempts"
+              break
+            fi
+            if [ $i -eq 15 ]; then
+              echo "FAIL: Gupax did not start"
+              docker logs gupax-test
+              exit 1
+            fi
+            sleep 2
+          done
 
       - name: Verify Tor SOCKS proxy (9050)
         timeout-minutes: 2


### PR DESCRIPTION
## Fixes #50

### Problem

The PR smoke test checked for the Gupax process immediately after noVNC became reachable, with no polling:

```yaml
- name: Verify Gupax process
  run: docker exec gupax-test pgrep -f gupax || fail
```

noVNC being reachable proves websockify is alive — not that `start.sh` has finished D-Bus, xdg-desktop-portal, and PUID/PGID user creation (3-6s after first noVNC response). The `pgrep` always fired too early.

### Evidence: ~80% failure rate on main

5 of the last 6 main branch runs failed. The one success was luck.

### Fix

Replace one-shot check with a 15-attempt × 2s polling loop (30s window), matching the pattern already used for Tor SOCKS, hidden service hostname, and noVNC probes in the same workflow:

```yaml
- name: Wait for Gupax process
  timeout-minutes: 2
  run: |
    for i in $(seq 1 15); do
      if docker exec gupax-test pgrep -f gupax 2>/dev/null; then
        echo "Gupax ready after ${i} attempts"
        break
      fi
      if [ $i -eq 15 ]; then
        echo "FAIL: Gupax did not start"
        docker logs gupax-test
        exit 1
      fi
      sleep 2
    done
```

### Testing

VM smoke test in progress. CI-only change — no runtime files modified.