### PR TITLE
fix: align Docker Hub version tags with GHCR (strip v prefix)

### DIFF
--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -33,12 +33,13 @@ jobs:
         run: |
           VERSION=$(curl -fsSL https://api.github.com/repos/gupax-io/gupax/releases/latest)
           VERSION=$(echo "$VERSION" | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
-          echo "Latest Gupax version: $VERSION"
+          VERSION_STRIPPED="${VERSION#v}"
+          echo "Latest Gupax version: $VERSION (tag: $VERSION_STRIPPED)"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           # Compute branch-aware tags. Replace slashes with hyphens (invalid in Docker tags).
           SAFE_REF=$(echo "${{ github.ref_name }}" | tr '/' '-')
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
+            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
           else
             TAGS="${{ env.IMAGE_NAME }}:${SAFE_REF}"$'\n'"${{ env.IMAGE_NAME }}:${SAFE_REF}-${{ github.sha }}"
           fi


### PR DESCRIPTION
## Fixes #2 from #47

### Problem

`docker-hub-push.yml` tagged images with the raw upstream version including the `v` prefix (`:v2.0.1`), while `docker-publish.yml` strips it (`:2.0.1`). Users switching between registries see inconsistent version schemes for the same image.

### Fix

Add `VERSION_STRIPPED="${VERSION#v}"` to the Docker Hub workflow version detection step and use it in the tag computation, exactly matching the GHCR workflow.

### Before → After
```
DH tag: libre7/gupax-docker:v2.0.1  →  libre7/gupax-docker:2.0.1
GHCR:  ghcr.io/libre-7/gupax-docker:2.0.1  (unchanged)
```

### Changes
- 1 file, +3/-2 lines
- CI workflow only — no runtime impact
- VM smoke test in progress

### Unraid test
Not needed — CI config change only.