### PR TITLE
fix: stale VNC_PASSWORD comment in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -266,7 +266,7 @@ setxkbmap us 2>/dev/null || echo "[!] setxkbmap failed (non-fatal)"
 
 # Start x11vnc (VNC server sharing Xvfb)
 echo "[*] Starting x11vnc on port 5900..."
-# VNC authentication — use VNC_PASSWORD if set, otherwise disable auth.
+# VNC authentication — use VNC_AUTH_TOKEN if set, otherwise disable auth.
 # Uses -passwdfile instead of -passwd to avoid exposing the password in
 # /proc/PID/cmdline and to handle passwords with spaces or special characters.
 if [ -n "$VNC_AUTH_TOKEN" ]; then


### PR DESCRIPTION
## Fixes #8 from #47

### Problem

`start.sh:269` comment says `use VNC_PASSWORD if set` but the code on line 272 checks `VNC_AUTH_TOKEN`. Stale from the VNC_PASSWORD → VNC_AUTH_TOKEN rename in v2.3.0.

### Fix

One word: `VNC_PASSWORD` → `VNC_AUTH_TOKEN` in the comment.

### Changes
- 1 file, 1 line
- Comment only — zero behavior impact

### Unraid test
Not needed — comment change, no runtime impact.