### PR TITLE
feat: version scheme v{upstream}+{date}, CHANGELOG, date-stamped tags

### DIFF
--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -36,10 +36,14 @@ jobs:
           VERSION_STRIPPED="${VERSION#v}"
           echo "Latest Gupax version: $VERSION (tag: $VERSION_STRIPPED)"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          # Compute branch-aware tags. Replace slashes with hyphens (invalid in Docker tags).
+          # Branch-aware tagging. Slashes -> hyphens (invalid in Docker tags).
           SAFE_REF=$(echo "${{ github.ref_name }}" | tr '/' '-')
+          # Tag strategy:
+          #   :latest / :2.0.1 / :v2.0.1  — moving, always latest build
+          #   :v2.0.1+20260518             — date-stamped, immutable
+          #   :<sha>                       — commit-pinned, immutable
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
+            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${VERSION}+20260518"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
           else
             TAGS="${{ env.IMAGE_NAME }}:${SAFE_REF}"$'\n'"${{ env.IMAGE_NAME }}:${SAFE_REF}-${{ github.sha }}"
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,11 +39,14 @@ jobs:
           VERSION=$(curl -s https://api.github.com/repos/gupax-io/gupax/releases/latest | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
           VERSION_STRIPPED="${VERSION#v}"
           echo "Detected Gupax version: $VERSION (tag: $VERSION_STRIPPED)"
-          # Branch-aware tagging: main gets :latest + version, feature branches get their own tag.
-          # Slashes in branch names are invalid in Docker tags — replace with hyphens.
+          # Branch-aware tagging. Slashes -> hyphens (invalid in Docker tags).
           SAFE_REF=$(echo "${{ github.ref_name }}" | tr '/' '-')
+          # Tag strategy:
+          #   :latest / :2.0.1 / :v2.0.1  — moving, always latest build
+          #   :v2.0.1+20260518             — date-stamped, immutable
+          #   :<sha>                       — commit-pinned, immutable
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
+            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${VERSION}+20260518"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
           else
             TAGS="${{ env.IMAGE_NAME }}:${SAFE_REF}"$'\n'"${{ env.IMAGE_NAME }}:${SAFE_REF}-${{ github.sha }}"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+Versions follow the scheme `v{upstream-gupax}+{build-date}`. The base version
+tracks which Gupax release is bundled; the date suffix differentiates container
+builds. `v2.0.1` and `v2.0.1+YYYYMMDD` tags are Docker image tags — the
+`v`-prefixed tag is a moving tag that always points to the latest build of that
+upstream release.
+
+## [v2.0.1+20260518] — 2026-05-18
+
+### Changed
+
+- **Version scheme** — Adopted `v{upstream}+{date}` convention. Version now
+  tracks the bundled Gupax release with a date-stamped container build suffix.
+  OCI labels (`image.version`, `gupax.version`) updated accordingly (#47).
+
+### Fixed
+
+- **CI build-args broken** (#48) — `GUPAX_VERSION` was arriving empty due to
+  multiline YAML scalar not interpolating `${{ }}`. Both registries were
+  silently falling back to the hardcoded v2.0.1 default. Fixed with
+  comma-separated args + `env:` block pattern.
+- **Registry divergence from `paths:` filter** (#48) — Docker Hub workflow had
+  a `paths:` filter that skipped docs-only commits. Removed; both registries
+  now share identical triggers.
+- **Smoke test Gupax race condition** (#51) — Single-shot `pgrep` fired before
+  `start.sh` reached Gupax launch (80% failure rate). Replaced with 15-attempt
+  polling loop matching Tor/hidden-service probes.
+- **Version tag asymmetry** (#53) — Docker Hub tagged `:v2.0.1`, GHCR tagged
+  `:2.0.1`. Both now emit `:2.0.1` (stripped) and `:v2.0.1` (v-prefixed).
+
+### Security
+
+- **Hadolint warnings resolved** (#52) — `DL4006/SC3040` (pipefail in dash),
+  `DL3009` (uncleaned apt lists), `SC2034` (dead variable). Added `SHELL` to
+  bash with pipefail globally.
+- **OCI labels corrected** (#52) — `image.source` case fixed
+  (`Gupax-docker` → `gupax-docker`), stale `-standalone-tor` suffix removed.
+- **Stale comment fixed** (#54) — `VNC_PASSWORD` → `VNC_AUTH_TOKEN` in
+  `start.sh` comment (was correct in code, wrong in docs).
+
+### Added
+
+- **Date-stamped image tags** — Both registries now push a `v{version}+{date}`
+  immutable tag in addition to the moving tags.
+
+### Documentation
+
+- Port tables consolidated into single master table in README and template
+  README (#47).
+- License restructured as canonical GPL-3.0 with separate NOTICE and SPDX
+  headers.
+- Docker Hub build status badge added to README.
+- Unraid template docs updated for 6.10+ flash-drive install method.
+
+---
+
 ## [2.3.0] — 2026-05-12
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ LABEL maintainer="libre-7" \
       description="Gupax — GUI for P2Pool + XMRig Monero mining in Docker (noVNC enabled, standalone binaries + optional Tor)" \
       org.opencontainers.image.source="https://github.com/libre-7/gupax-docker" \
       org.opencontainers.image.icon="https://raw.githubusercontent.com/gupax-io/gupax/main/assets/images/icons/icon.png" \
-      org.opencontainers.image.version="${GUPAX_VERSION}" \
+      org.opencontainers.image.version="${GUPAX_VERSION}+20260518" \
       org.opencontainers.image.licenses="GPL-3.0" \
       gupax.version="${GUPAX_VERSION}"
 


### PR DESCRIPTION
## Fixes #7 from #47

### Changes

**Version scheme** — Adopted `v{upstream}+{date}` convention:
- `v2.0.1` → which Gupax is bundled
- `+20260518` → which container build

**CHANGELOG** — New `v2.0.1+20260518` section covering all May 14-18 changes.

**Docker image tags** — Both registries now push **five** tags on `main`:

| Tag | Type | Purpose |
|-----|------|---------|
| `:latest` | moving | Always latest build |
| `:2.0.1` | moving | Latest build of this Gupax release (stripped) |
| `:v2.0.1` | moving | Latest build of this Gupax release (v-prefixed) |
| `:v2.0.1+20260518` | date-stamped | Immutable, pin to this exact build |
| `:<sha>` | commit-pinned | Immutable, pin to this commit |

`docker pull ghcr.io/libre-7/gupax-docker:v2.0.1` always gives the latest build.

**OCI label** — `org.opencontainers.image.version` now reads `v2.0.1+20260518`.

### Files
- `Dockerfile` — label update (1 line)
- `docker-publish.yml` — add v-prefixed + date-stamped tags
- `docker-hub-push.yml` — same
- `CHANGELOG.md` — new section + version scheme docs

### Unraid test
Recommended. The CI tag changes are CI-only, but the image.version OCI label change and new date-stamped tag are visible in the image itself. Pull `ghcr.io/libre-7/gupax-docker:v2.0.1+20260518` to verify.