### PR TITLE
fix: replace + with - in Docker tags (invalid reference format)

### DIFF
--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -40,10 +40,10 @@ jobs:
           SAFE_REF=$(echo "${{ github.ref_name }}" | tr '/' '-')
           # Tag strategy:
           #   :latest / :2.0.1 / :v2.0.1  — moving, always latest build
-          #   :v2.0.1+20260518             — date-stamped, immutable
+          #   :v2.0.1-20260518             — date-stamped, immutable
           #   :<sha>                       — commit-pinned, immutable
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${VERSION}+20260518"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
+            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${VERSION}-20260518"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
           else
             TAGS="${{ env.IMAGE_NAME }}:${SAFE_REF}"$'\n'"${{ env.IMAGE_NAME }}:${SAFE_REF}-${{ github.sha }}"
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,10 +43,10 @@ jobs:
           SAFE_REF=$(echo "${{ github.ref_name }}" | tr '/' '-')
           # Tag strategy:
           #   :latest / :2.0.1 / :v2.0.1  — moving, always latest build
-          #   :v2.0.1+20260518             — date-stamped, immutable
+          #   :v2.0.1-20260518             — date-stamped, immutable
           #   :<sha>                       — commit-pinned, immutable
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${VERSION}+20260518"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
+            TAGS="${{ env.IMAGE_NAME }}:latest"$'\n'"${{ env.IMAGE_NAME }}:$VERSION_STRIPPED"$'\n'"${{ env.IMAGE_NAME }}:$VERSION"$'\n'"${{ env.IMAGE_NAME }}:${VERSION}-20260518"$'\n'"${{ env.IMAGE_NAME }}:${{ github.sha }}"
           else
             TAGS="${{ env.IMAGE_NAME }}:${SAFE_REF}"$'\n'"${{ env.IMAGE_NAME }}:${SAFE_REF}-${{ github.sha }}"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-Versions follow the scheme `v{upstream-gupax}+{build-date}`. The base version
+Versions follow the scheme `v{upstream-gupax}-{build-date}`. The base version
 tracks which Gupax release is bundled; the date suffix differentiates container
 builds. `v2.0.1` and `v2.0.1+YYYYMMDD` tags are Docker image tags — the
 `v`-prefixed tag is a moving tag that always points to the latest build of that
 upstream release.
 
-## [v2.0.1+20260518] — 2026-05-18
+## [v2.0.1-20260518] — 2026-05-18
 
 ### Changed
 
-- **Version scheme** — Adopted `v{upstream}+{date}` convention. Version now
+- **Version scheme** — Adopted `v{upstream}-{date}` convention. Version now
   tracks the bundled Gupax release with a date-stamped container build suffix.
   OCI labels (`image.version`, `gupax.version`) updated accordingly (#47).
 
@@ -45,7 +45,7 @@ upstream release.
 
 ### Added
 
-- **Date-stamped image tags** — Both registries now push a `v{version}+{date}`
+- **Date-stamped image tags** — Both registries now push a `v{version}-{date}`
   immutable tag in addition to the moving tags.
 
 ### Documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ LABEL maintainer="libre-7" \
       description="Gupax — GUI for P2Pool + XMRig Monero mining in Docker (noVNC enabled, standalone binaries + optional Tor)" \
       org.opencontainers.image.source="https://github.com/libre-7/gupax-docker" \
       org.opencontainers.image.icon="https://raw.githubusercontent.com/gupax-io/gupax/main/assets/images/icons/icon.png" \
-      org.opencontainers.image.version="${GUPAX_VERSION}+20260518" \
+      org.opencontainers.image.version="${GUPAX_VERSION}-20260518" \
       org.opencontainers.image.licenses="GPL-3.0" \
       gupax.version="${GUPAX_VERSION}"
 


### PR DESCRIPTION
## Emergency fix for #55

### Problem

The `+` in `v2.0.1+20260518` is invalid in Docker tag names (only `[a-zA-Z0-9_.-]` allowed). Both registry pushes failed with:

```
invalid tag "...:v2.0.1+20260518": invalid reference format
```

### Fix

Replaced `+` with `-` across all four files:
- `docker-publish.yml` / `docker-hub-push.yml` — tag computation
- `Dockerfile` — OCI `image.version` label
- `CHANGELOG.md` — version scheme docs + section heading

**New format:** `v2.0.1-20260518`

### Note

`+` is the SemVer build-metadata separator but Docker rejects it. `-` is pragmatically correct here — it reads as a hyphenated identifier (`v2.0.1-build-20260518`), which is valid per OCI tag spec.

### Testing

PR checks will confirm tags build. VM test in progress.