### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to gupax-docker
+
+Thanks for contributing! This document covers how to submit changes,
+what gets tested, and the conventions in use.
+
+## Quick start
+
+1. Fork the repo and clone it
+2. Create a branch: `fix/descriptive-name` or `feat/descriptive-name`
+3. Make your changes
+4. Push and open a PR against `main`
+
+That's it. CI will lint your changes and run a smoke test automatically.
+
+## What CI checks
+
+Every PR runs through `pr-tests.yml`:
+
+- **ShellCheck** — catches bugs in shell scripts
+- **Hadolint** — Dockerfile best practices
+- **YAML lint** — workflow and compose syntax
+- **Smoke test** — builds the image and verifies the container starts
+  with Gupax running and Tor operational
+
+PRs that only touch docs (README, CHANGELOG, templates) still trigger CI
+because linting and smoke testing are cheap and catch regressions.
+
+## Commit messages
+
+Use conventional commit prefixes:
+
+```
+fix: describe what was broken and how it's fixed
+feat: describe the new capability
+docs: documentation only
+```
+
+Reference issues in the body (`Refs #N`) rather than the subject line.
+Use `Closes #N` only after the fix is confirmed on Unraid production.
+
+## Branch naming
+
+```
+fix/env-var-naming-mismatch
+feat/tor-health-check
+docs/port-table-consolidation
+```
+
+Hyphens, lowercase, descriptive.
+
+## Issue lifecycle
+
+All issues follow this flow:
+
+```
+Investigate → Present findings → Get approval → Implement → VM test → Unraid test → Close
+```
+
+- **VM test** is a build/startup smoke test at `192.168.1.127`. It confirms
+  the image builds and the container starts — not that everything works
+  end-to-end.
+- **Unraid test** is the final verification. The project maintainer runs the
+  change on their Unraid production server before any issue is closed.
+- **CI-only changes** (workflow files, lint configs) and **docs-only changes**
+  skip Unraid testing.
+
+Never close an issue based on a VM test alone. The user always tests on
+Unraid first.
+
+## Dockerfile conventions
+
+- Base image is digest-pinned (`ubuntu:22.04@sha256:...`)
+- All `RUN` commands use bash with `pipefail` (global `SHELL` directive)
+- `apt-get install` always includes `--no-install-recommends` and cleanup
+  in the same layer (`rm -rf /var/lib/apt/lists/*`)
+- Tor is installed from the Tor Project apt repo, not Ubuntu's stale package
+- The container starts as root so `start.sh` can fix volume permissions,
+  then drops to the `miner` user via `gosu`
+
+## Shell script conventions
+
+- `#!/bin/bash` with `set -e` or `&&` chaining
+- SPDX header: `# SPDX-License-Identifier: GPL-3.0-or-later`
+- Graceful shutdown via `trap` + `cleanup` function
+- No secrets in `/proc/PID/cmdline` (use `-passwdfile`, not `-passwd`)
+
+## Version scheme
+
+- Images are tagged `v{upstream-gupax}-{build-date}` (e.g. `v2.0.1-20260518`)
+- The `v2.0.1` base tracks which Gupax is bundled
+- The `-20260518` suffix differentiates container builds
+- Moving tags (`:latest`, `:v2.0.1`, `:2.0.1`) always point to the latest build
+
+## Registry flow
+
+On merge to `main`, both registries are updated:
+
+```
+main commit → GHCR (ghcr.io/libre-7/gupax-docker)
+            → Docker Hub (docker.io/libre7/gupax-docker)
+```
+
+Feature branches don't push to registries unless explicitly configured.
+
+## Where to find things
+
+| What | Where |
+|------|-------|
+| Dockerfile | `./Dockerfile` |
+| Entrypoint | `./start.sh` |
+| Health check | `./healthcheck.sh` |
+| Compose config | `./docker-compose.yml` |
+| CI workflows | `.github/workflows/` |
+| Unraid template | `templates/gupax-docker.xml` |
+| Release history | `CHANGELOG.md` |
+| Roadmap | `TODO.md` |
+| Security policy | `SECURITY.md` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `:latest` (main branch) | ✅ |
+| Date-stamped tags (`v2.0.1-YYYYMMDD`) | ✅ |
+| Feature branch tags | ⚠️ Unstable — development only |
+
+The `:latest` tag and date-stamped tags receive security fixes. Feature
+branch tags are development snapshots and may not receive prompt updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in gupax-docker, please **do not**
+open a public GitHub issue.
+
+Please report it privately via GitHub Security Advisories:
+
+1. Go to the [Security tab](https://github.com/libre-7/gupax-docker/security)
+2. Click **Report a vulnerability**
+3. Describe the issue with as much detail as possible
+
+You can also email **libre7@proton.me** with the details.
+
+### What to include
+
+- A clear description of the vulnerability
+- Steps to reproduce or a proof-of-concept
+- Affected versions or configurations
+- Potential impact to users
+
+### What to expect
+
+- **Acknowledgment:** Within 48 hours
+- **Assessment:** Within 7 days — we'll evaluate severity and confirm whether
+  it applies
+- **Fix timeline:** Critical issues will be patched as quickly as possible,
+  typically within 2–4 weeks depending on complexity
+- **Disclosure:** We'll coordinate public disclosure with you. You'll be
+  credited in the release notes unless you prefer to remain anonymous
+
+### Out of scope
+
+- Issues that require physical access to the host machine
+- Vulnerabilities in upstream projects (Gupax, P2Pool, XMRig, monerod) —
+  please report those to the respective projects directly
+- Theoretical attacks that require the attacker to already have root on the
+  Docker host
+
+## Security-relevant Configuration
+
+The following environment variables and settings directly affect the security
+posture of the container:
+
+| Setting | Effect |
+|---------|--------|
+| `VNC_AUTH_TOKEN` | Required for VNC access on port 5900. Without it, anyone on your network can control the Gupax GUI. |
+| `TOR_ENABLED=true` | Routes transaction broadcasts through Tor for privacy. P2P sync stays on clearnet. |
+| `MONERO_RPC_RESTRICTED=true` | Restricts RPC to view-only commands. Set to `false` only if you understand the implications. |
+| `--rpc-login` | Do **not** use with Gupax-managed monerod — incompatible. Use `--restricted-rpc` instead. |
+
+The container runs with `cap_drop: [ALL]` and only adds back the minimum
+capabilities needed (`SETUID`, `SETGID`, `DAC_OVERRIDE`, `FOWNER`, `CHOWN`).
+It runs as a non-root `miner` user at runtime.
+
+On Unraid, the FUSE filesystem silently ignores `chown`, requiring a fallback
+to world-writable permissions on persistent volumes. This is a fundamental
+Unraid limitation documented in the README's Security Notes section.


### PR DESCRIPTION
## Fixes #9 from #47

### SECURITY.md
- Supported versions table
- Vulnerability reporting via GitHub Security Advisories or email
- Expected response timelines
- Scope boundaries
- Security-relevant configuration overview (VNC_AUTH_TOKEN, TOR_ENABLED, MONERO_RPC_RESTRICTED, --rpc-login caveat, FUSE permission trade-off)

### CONTRIBUTING.md
- PR workflow, CI checks
- Commit message and branch naming conventions
- Issue lifecycle (investigate → present → approve → implement → VM → Unraid)
- Dockerfile and shell script conventions
- Version scheme documentation
- Registry flow (main → GHCR + Docker Hub)
- Project file map

### Testing
Docs-only — no CI or VM test needed.