### PR TITLE
docs: complete .env.example with all env vars; consistent EXPOSE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,48 @@
 # =============================================================================
 # Gupax-docker Environment Variables
-# Copy this file to .env and fill in your values
+# Copy this file to .env and uncomment values you want to customize.
+# All variables have sensible defaults — the container works out of the box.
 # =============================================================================
 
-# Optional: Monero blockchain data path
-# Mount a host directory or named volume containing your existing blockchain
-# If empty, defaults to named volume 'gupax-monero'
-# Example (host directory): /path/to/my/blockchain:/home/miner/.bitmonero
-# Example (named volume): gupax-my-blockchain:/home/miner/.bitmonero
-MONERO_DATA_PATH=
+# --- Tor ---
 
-# Monero RPC security — restrict to view-only commands (default: true)
-# Set to false only if you need full RPC access for external wallets or debug tools.
-# When Tor is enabled, this controls --restricted-rpc in the recommended monerod args.
+# Enable Tor for private transaction broadcast (tx-only mode, P2P sync stays
+# on clearnet). Also creates a hidden service so wallets can connect over Tor.
+# Default: false
+# TOR_ENABLED=false
+
+# --- VNC Security ---
+
+# Require a password for VNC web interface access.
+# Leave empty (default) for no authentication.
+# VNC_AUTH_TOKEN=
+
+# --- Monero Node ---
+
+# Restrict RPC to safe, view-only commands (get_info, get_height, etc.).
+# Set to false only if you need full RPC access for external wallets or debug
+# tools. When Tor is enabled, this sets --restricted-rpc on monerod.
+# Default: true
 # MONERO_RPC_RESTRICTED=true
+
+# --- File Permissions ---
+
+# User/group ID for volume ownership. Auto-detected from the volume owner
+# if not set. On Unraid this typically defaults to 99:100.
+# PUID=99
+# PGID=100
+
+# --- Display ---
+
+# Resolution for the virtual X display running Gupax.
+# Default: 1920x1080x24
+# SCREEN_RESOLUTION=1920x1080x24
+
+# --- Blockchain ---
+
+# Optional: host path or named volume containing an existing Monero blockchain.
+# If empty, defaults to a named volume 'gupax-monero'.
+# MONERO_DATA_PATH=
 
 # =============================================================================
 # ACCESSING THE GUI

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,11 +127,10 @@ RUN echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=v
 COPY start.sh /usr/local/bin/start.sh
 COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/start.sh /usr/local/bin/healthcheck.sh
-
 EXPOSE 6080 5900
 EXPOSE 3333 37889 18080 18081
-# Tor hidden service ports (internal only — documented for debugging)
-EXPOSE 18084 18086
+# Internal-only ports (documented for debugging — not mapped to host)
+EXPOSE 18083 18084 18086 9050
 
 # Pre-create .bitmonero directory with miner ownership.
 # No .bitmonero symlink needed — monerod resolves its data directory via $HOME


### PR DESCRIPTION
## Fixes #11 and #13 from #47

### #11 — .env.example now covers all 7 env vars

| Before | After |
|--------|-------|
| Only MONERO_DATA_PATH and MONERO_RPC_RESTRICTED | All 7 env vars with defaults, sections, comments |

New sections: Tor (TOR_ENABLED), VNC (VNC_AUTH_TOKEN), Node (MONERO_RPC_RESTRICTED), Permissions (PUID/PGID), Display (SCREEN_RESOLUTION), Blockchain (MONERO_DATA_PATH)

### #13 — EXPOSE now covers all internal-only ports

| Before | After |
|--------|-------|
| 18084, 18086 | 18083 (ZMQ), 18084 (Tor HS P2P), 18086 (Tor HS bind), 9050 (Tor SOCKS) |

Consolidated under one comment: "Internal-only ports (documented for debugging — not mapped to host)"

### Testing
Docs-only — no CI or VM test needed.