### PR TITLE
docs: de-duplicate template overview, add volume name cross-reference

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -4,7 +4,7 @@ This directory contains the Docker template XML file for installing **Gupax-dock
 
 The Docker image is published to both:
 - **Docker Hub**: [libre7/gupax-docker](https://hub.docker.com/r/libre7/gupax-docker) (recommended for Unraid)
-- **GitHub Container Registry**: [ghcr.io/libre-7/gupax-docker](https://github.com/libre-7/Gupax-docker/pkgs/container/gupax-docker)
+- **GitHub Container Registry**: [ghcr.io/libre-7/gupax-docker](https://github.com/libre-7/gupax-docker/pkgs/container/gupax-docker)
 
 ## How to Use
 
@@ -63,12 +63,17 @@ The container runs a **noVNC web interface** — no X11 or VNC client needed:
 
 ## Volumes
 
-The template creates four persistent directories under `/mnt/user/appdata/gupax/`:
+The template creates four persistent directories under `/mnt/user/appdata/gupax/`.
 
-- `config/` — Gupax configuration, wallet, and state
-- `share/` — Downloaded mining binaries (P2Pool, XMRig, monerod)
-- `monero/` — Monero blockchain data
-- `tor/` — Tor hidden service keys (persists .onion address)
+Unraid uses host directory paths; `docker compose` uses named volumes.
+The data is the same — only the storage mechanism differs.
+
+| Unraid directory | Container path | Compose named volume |
+|------------------|----------------|---------------------|
+| `config/` | `/home/miner/.local/state/gupax` | `gupax-state` |
+| `share/` | `/home/miner/.local/share/gupax` | `gupax-data` |
+| `monero/` | `/home/miner/.bitmonero` | `gupax-monero` |
+| `tor/` | `/home/miner/.tor` | `gupax-tor` |
 
 ## Using an Existing Blockchain
 

--- a/templates/gupax-docker.xml
+++ b/templates/gupax-docker.xml
@@ -9,7 +9,7 @@
   <Privileged>false</Privileged>
   <Support>https://github.com/libre-7/gupax-docker/issues</Support>
   <Project>https://github.com/libre-7/gupax-docker</Project>
-  <Overview>Gupax-docker runs the Gupax GUI for P2Pool + XMRig Monero mining via noVNC web interface.</Overview>
+  <Overview>Browser-based Monero mining — P2Pool + XMRig GUI with optional Tor</Overview>
   <Description>
     Gupax-docker runs the Gupax GUI for P2Pool + XMRig Monero mining via a noVNC web interface.
 


### PR DESCRIPTION
## Fixes #15 and #16 from #47

### #15 - Template overview/description overlap

- Before: Overview was nearly verbatim the first line of Description
- After: Shorter, distinct summary: "Browser-based Monero mining — P2Pool + XMRig GUI with optional Tor"

### #16 - Volume name mismatch between template README and compose

Added a cross-reference table mapping Unraid host directories to their corresponding compose named volumes, making the relationship explicit.

Also fixed GHCR link case (Gupax-docker to gupax-docker).

### #14 - Git tags status

v2.0.1 tag already exists via CI push. GitHub Releases remain a manual step.

### Testing
Docs-only - no CI or VM test needed.
