### PR TITLE
feat: update monerod args for v0.18.5.0 (SOCKS5, drop UPnP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ You'll see output like:
 
 [+] Recommended monerod arguments (Gupax → Node → Arguments):
     --restricted-rpc
-    --no-igd
-    --tx-proxy=tor,127.0.0.1:9050
+    --tx-proxy=socks5://127.0.0.1:9050
     --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
 ```
 
@@ -150,13 +149,13 @@ You'll see output like:
 **5. Paste the four Tor arguments** from the log output (after the `--data-dir` fix):
 
 ```
---restricted-rpc --no-igd --tx-proxy=tor,127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
+--restricted-rpc --tx-proxy=socks5://127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
 ```
 
 The complete Start options line should look like:
 
 ```
---data-dir /home/miner/.bitmonero --zmq-pub tcp://127.0.0.1:18083 --rpc-bind-ip 127.0.0.1 --rpc-bind-port 18081 --out-peers 8 --in-peers 16 --log-level 0 --sync-pruned-blocks --enable-dns-blocklist --disable-dns-checkpoints --prune-blockchain --restricted-rpc --no-igd --tx-proxy=tor,127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
+--data-dir /home/miner/.bitmonero --zmq-pub tcp://127.0.0.1:18083 --rpc-bind-ip 127.0.0.1 --rpc-bind-port 18081 --out-peers 8 --in-peers 16 --log-level 0 --sync-pruned-blocks --enable-dns-blocklist --disable-dns-checkpoints --prune-blockchain --restricted-rpc --tx-proxy=socks5://127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
 ```
 
 **6. Click Save** (Gupax does not auto-save — if you skip this, the arguments are lost on restart)
@@ -193,7 +192,7 @@ Once monerod is running, you can connect any Monero wallet through the same `.on
 monero-wallet-cli --daemon-address <onion>:18081 --proxy 127.0.0.1:9050
 ```
 
-> **How it works:** The hidden service maps `:18081` directly to monerod's JSON-RPC at `127.0.0.1:18081`. Wallet sync (`get_blocks.bin`) and transaction submission (`send_raw_transaction`) both flow through this port. Transaction broadcast from monerod to the network uses `--tx-proxy=tor,...` to route through SOCKS5.
+> **How it works:** The hidden service maps `:18081` directly to monerod's JSON-RPC at `127.0.0.1:18081`. Wallet sync (`get_blocks.bin`) and transaction submission (`send_raw_transaction`) both flow through this port. Transaction broadcast from monerod to the network uses `--tx-proxy=socks5://127.0.0.1:9050` to route through SOCKS5.
 
 ---
 ## 🖥️ Unraid Setup

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ You'll see output like:
 
 [+] Recommended monerod arguments (Gupax → Node → Arguments):
     --restricted-rpc
-    --tx-proxy=socks5://127.0.0.1:9050
+    --tx-proxy=socks5,127.0.0.1:9050
     --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
-```
 
+This tells monerod to route ALL transaction traffic through the Tor SOCKS5 proxy on localhost:9050.
 **2. Open the Gupax web UI** at `http://your-server:6080`
 
 **3. Go to the Node tab** and switch from **Simple** to **Advanced** mode to reveal the **"Start options:"** text box
@@ -149,13 +149,13 @@ You'll see output like:
 **5. Paste the four Tor arguments** from the log output (after the `--data-dir` fix):
 
 ```
---restricted-rpc --tx-proxy=socks5://127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
+--restricted-rpc --tx-proxy=socks5,127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
 ```
 
 The complete Start options line should look like:
 
 ```
---data-dir /home/miner/.bitmonero --zmq-pub tcp://127.0.0.1:18083 --rpc-bind-ip 127.0.0.1 --rpc-bind-port 18081 --out-peers 8 --in-peers 16 --log-level 0 --sync-pruned-blocks --enable-dns-blocklist --disable-dns-checkpoints --prune-blockchain --restricted-rpc --tx-proxy=socks5://127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
+--data-dir /home/miner/.bitmonero --zmq-pub tcp://127.0.0.1:18083 --rpc-bind-ip 127.0.0.1 --rpc-bind-port 18081 --out-peers 8 --in-peers 16 --log-level 0 --sync-pruned-blocks --enable-dns-blocklist --disable-dns-checkpoints --prune-blockchain --restricted-rpc --tx-proxy=socks5,127.0.0.1:9050 --anonymous-inbound=dqwj5fyc...onion:18084,127.0.0.1:18086,40
 ```
 
 **6. Click Save** (Gupax does not auto-save — if you skip this, the arguments are lost on restart)
@@ -192,7 +192,7 @@ Once monerod is running, you can connect any Monero wallet through the same `.on
 monero-wallet-cli --daemon-address <onion>:18081 --proxy 127.0.0.1:9050
 ```
 
-> **How it works:** The hidden service maps `:18081` directly to monerod's JSON-RPC at `127.0.0.1:18081`. Wallet sync (`get_blocks.bin`) and transaction submission (`send_raw_transaction`) both flow through this port. Transaction broadcast from monerod to the network uses `--tx-proxy=socks5://127.0.0.1:9050` to route through SOCKS5.
+> **How it works:** The hidden service maps `:18081` directly to monerod's JSON-RPC at `127.0.0.1:18081`. Wallet sync (`get_blocks.bin`) and transaction submission (`send_raw_transaction`) both flow through this port. Transaction broadcast from monerod to the network uses `--tx-proxy=socks5,127.0.0.1:9050` to route through SOCKS5.
 
 ---
 ## 🖥️ Unraid Setup

--- a/start.sh
+++ b/start.sh
@@ -197,8 +197,7 @@ TORRC
         # the Node tab from showing green and blocking P2Pool startup.
         # P2Pool v4.x also rejects --rpc-login=user:pass (= syntax).
         # Use --restricted-rpc for loopback-only RPC access (sufficient here).
-        echo "    --no-igd"
-        echo "    --tx-proxy=tor,127.0.0.1:9050"
+        echo "    --tx-proxy=socks5://127.0.0.1:9050"
         echo "    --anonymous-inbound=${HS_KEY}:18084,127.0.0.1:18086,40"
         # Persist for reference across container restarts
         echo "Monero .onion: ${HS_HOSTNAME}" > /home/miner/.tor/monerod_onion.txt
@@ -212,8 +211,7 @@ TORRC
         fi
         # --rpc-login omitted: Gupax watchdog has no auth support (HTTP 401).
         # --restricted-rpc is sufficient for loopback-only RPC access.
-        echo "  --no-igd" >> /home/miner/.tor/monerod_onion.txt
-        echo "  --tx-proxy=tor,127.0.0.1:9050" >> /home/miner/.tor/monerod_onion.txt
+        echo "  --tx-proxy=socks5://127.0.0.1:9050" >> /home/miner/.tor/monerod_onion.txt
         echo "  --anonymous-inbound=${HS_KEY}:18084,127.0.0.1:18086,40" >> /home/miner/.tor/monerod_onion.txt
     fi
     # Signal file so the Docker health check knows Tor was started —

--- a/start.sh
+++ b/start.sh
@@ -197,7 +197,7 @@ TORRC
         # the Node tab from showing green and blocking P2Pool startup.
         # P2Pool v4.x also rejects --rpc-login=user:pass (= syntax).
         # Use --restricted-rpc for loopback-only RPC access (sufficient here).
-        echo "    --tx-proxy=socks5://127.0.0.1:9050"
+        echo "    --tx-proxy=socks5,127.0.0.1:9050"
         echo "    --anonymous-inbound=${HS_KEY}:18084,127.0.0.1:18086,40"
         # Persist for reference across container restarts
         echo "Monero .onion: ${HS_HOSTNAME}" > /home/miner/.tor/monerod_onion.txt
@@ -211,7 +211,7 @@ TORRC
         fi
         # --rpc-login omitted: Gupax watchdog has no auth support (HTTP 401).
         # --restricted-rpc is sufficient for loopback-only RPC access.
-        echo "  --tx-proxy=socks5://127.0.0.1:9050" >> /home/miner/.tor/monerod_onion.txt
+        echo "  --tx-proxy=socks5,127.0.0.1:9050" >> /home/miner/.tor/monerod_onion.txt
         echo "  --anonymous-inbound=${HS_KEY}:18084,127.0.0.1:18086,40" >> /home/miner/.tor/monerod_onion.txt
     fi
     # Signal file so the Docker health check knows Tor was started —


### PR DESCRIPTION
## Changes

Updates recommended monerod CLI arguments for Monero v0.18.5.0 (Fluorine Fermi).

### 1. `--tx-proxy` SOCKS4 → SOCKS5 format
- Old: `--tx-proxy=tor,127.0.0.1:9050`
- New: `--tx-proxy=socks5://127.0.0.1:9050`
- Upstream PRs: #9443 / #10411

### 2. Remove `--no-igd` (now a no-op)
UPnP support was removed from monerod entirely (PR #10465). The flag is harmless but meaningless.

### Files changed
- **start.sh** — 4 occurrences (2 banner echo, 2 monerod_onion.txt persist)
- **README.md** — 5 occurrences (example args, commands, narrative)

### Testing
- [ ] VM smoke test with `TOR_ENABLED=true`
- [ ] Unraid test (after Gupax upgrades monerod to 0.18.5.0)

Refs #46